### PR TITLE
Added missing return when ruletype can't be found

### DIFF
--- a/fuglu/src/fuglu/plugins/attachment.py
+++ b/fuglu/src/fuglu/plugins/attachment.py
@@ -87,6 +87,7 @@ class RulesCache(object):
         self.logger.debug('Rule cache request: [%s] [%s]' % (ruletype, key))
         if not self.rules.has_key(ruletype):
             self.logger.error('Invalid rule type requested: %s' % ruletype)
+            return None
         if not self.rules[ruletype].has_key(key):
             self.logger.debug(
                 'Ruleset not found : [%s] [%s]' % (ruletype, key))


### PR DESCRIPTION
In attachment plugin, when requesting a rule type that can't be found.
The error show in the logs but the method doesn't return, causing an exception when trying to access self.rules[ruletype] in following test.
