### PR TITLE
set SAPlugin.report tag with spamheader if forwardoriginal=0

### DIFF
--- a/fuglu/src/fuglu/plugins/sa.py
+++ b/fuglu/src/fuglu/plugins/sa.py
@@ -52,6 +52,7 @@ Tags:
  * sets ``spam['spamassassin']`` (boolean)
  * sets ``SAPlugin.spamscore`` (float) if possible
  * sets ``SAPlugin.skipreason`` (string) if the message was not scanned (fuglu >0.5.0)
+ * sets ``SAPlugin.report`` (string) spamheader (where score if found) or spamreport from spamd depending on forwardoriginal setting
 """
 
     def __init__(self, config, section=None):
@@ -346,6 +347,7 @@ Tags:
             else:
                 self.logger.warning('%s Could not extract spam score from header: %s' % (suspect.id, spamheader))
                 suspect.debug( 'Could not read spam score from header %s' % spamheader)
+            return isspam, spamscore, spamheader
         return isspam, spamscore
 
 
@@ -468,7 +470,8 @@ Tags:
             if stripped:
                 self.logger.warning('%s forwarding truncated message')
             spamheadername = self.config.get(self.section, 'spamheader')
-            isspam, spamscore = self._extract_spamstatus(newmsgrep, spamheadername, suspect)
+            isspam, spamscore, report = self._extract_spamstatus(newmsgrep, spamheadername, suspect)
+            suspect.tags['SAPlugin.report'] = report
 
         action = DUNNO
         message = None

--- a/fuglu/src/fuglu/plugins/sa.py
+++ b/fuglu/src/fuglu/plugins/sa.py
@@ -52,7 +52,7 @@ Tags:
  * sets ``spam['spamassassin']`` (boolean)
  * sets ``SAPlugin.spamscore`` (float) if possible
  * sets ``SAPlugin.skipreason`` (string) if the message was not scanned (fuglu >0.5.0)
- * sets ``SAPlugin.report`` (string) spamheader (where score if found) or spamreport from spamd depending on forwardoriginal setting
+ * sets ``SAPlugin.report`` (string) spamheader (where score is found) or spamreport from spamd depending on forwardoriginal setting
 """
 
     def __init__(self, config, section=None):

--- a/fuglu/tests/unit/plugins_sa_test.py
+++ b/fuglu/tests/unit/plugins_sa_test.py
@@ -49,7 +49,7 @@ class SATestCase(unittest.TestCase):
         for headercontent, expectedspamstatus, expectedscore in headertests:
             msgrep = Message()
             msgrep[headername] = Header(headercontent).encode()
-            spamstatus, score = candidate._extract_spamstatus(
+            spamstatus, score, report = candidate._extract_spamstatus(
                 msgrep, headername, suspect)
             self.assertEqual(spamstatus, expectedspamstatus, "spamstatus should be %s from %s" % (
                 expectedspamstatus, headercontent))


### PR DESCRIPTION
if forwardoriginal=0 no suspect.tags['SAPlugin.report'] is currently added. Changed  _extract_spamstatus() to return spamheader as third value and  examine() to add suspect.tags['SAPlugin.report'] = spamheader in case of  forwardoriginal=0 So later plugins can catch on spamheader via suspect.tags['SAPlugin.report'] regardless of forwardoriginal. The idea is to allow a later plugin to react on certain spamassassin  symbols and for example mark a matching msg as infected (virus=y)


