### PR TITLE
support strip_oversize if forwardoriginal=0

### DIFF
--- a/fuglu/src/fuglu/plugins/sa.py
+++ b/fuglu/src/fuglu/plugins/sa.py
@@ -52,6 +52,7 @@ Tags:
  * sets ``spam['spamassassin']`` (boolean)
  * sets ``SAPlugin.spamscore`` (float) if possible
  * sets ``SAPlugin.skipreason`` (string) if the message was not scanned (fuglu >0.5.0)
+ * sets ``SAPlugin.report`` (string) spamheader (where score if found) or spamreport from spamd depending on forwardoriginal setting
 """
 
     def __init__(self, config, section=None):
@@ -346,6 +347,7 @@ Tags:
             else:
                 self.logger.warning('%s Could not extract spam score from header: %s' % (suspect.id, spamheader))
                 suspect.debug( 'Could not read spam score from header %s' % spamheader)
+            return isspam, spamscore, spamheader
         return isspam, spamscore
 
 
@@ -468,7 +470,8 @@ Tags:
             if stripped:
                 self.logger.warning('%s forwarding truncated message')
             spamheadername = self.config.get(self.section, 'spamheader')
-            isspam, spamscore = self._extract_spamstatus(newmsgrep, spamheadername, suspect)
+            isspam, spamscore, report = self._extract_spamstatus(newmsgrep, spamheadername, suspect)
+            suspect.tags['SAPlugin.report'] = report
 
         action = DUNNO
         message = None

--- a/fuglu/src/fuglu/plugins/sa.py
+++ b/fuglu/src/fuglu/plugins/sa.py
@@ -52,7 +52,7 @@ Tags:
  * sets ``spam['spamassassin']`` (boolean)
  * sets ``SAPlugin.spamscore`` (float) if possible
  * sets ``SAPlugin.skipreason`` (string) if the message was not scanned (fuglu >0.5.0)
- * sets ``SAPlugin.report`` (string) spamheader (where score if found) or spamreport from spamd depending on forwardoriginal setting
+ * sets ``SAPlugin.report`` (string) spamheader (where score is found) or spamreport from spamd depending on forwardoriginal setting
 """
 
     def __init__(self, config, section=None):

--- a/fuglu/src/fuglu/plugins/sa.py
+++ b/fuglu/src/fuglu/plugins/sa.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 #
 #
-import email
-import os
-import re
-import socket
-import sys
-import time
-from string import Template
-
+from fuglu.shared import ScannerPlugin, DUNNO, DEFER, Suspect, string_to_actioncode, apply_template
 from fuglu.extensions.sql import DBConfig, get_session, SQL_EXTENSION_ENABLED
 from fuglu.localStringEncoding import force_bString, force_uString
-from fuglu.shared import ScannerPlugin, DUNNO, DEFER, Suspect, string_to_actioncode, apply_template
+from string import Template
+import time
+import socket
+import email
+import re
+import os
+import sys
+
 
 GTUBE = """Date: Mon, 08 Sep 2008 17:33:54 +0200
 To: oli@unittests.fuglu.org

--- a/fuglu/tests/unit/plugins_sa_test.py
+++ b/fuglu/tests/unit/plugins_sa_test.py
@@ -49,7 +49,7 @@ class SATestCase(unittest.TestCase):
         for headercontent, expectedspamstatus, expectedscore in headertests:
             msgrep = Message()
             msgrep[headername] = Header(headercontent).encode()
-            spamstatus, score = candidate._extract_spamstatus(
+            spamstatus, score, report = candidate._extract_spamstatus(
                 msgrep, headername, suspect)
             self.assertEqual(spamstatus, expectedspamstatus, "spamstatus should be %s from %s" % (
                 expectedspamstatus, headercontent))


### PR DESCRIPTION
currently if strip_oversize is set and forwardoriginal is 0 the resulting messages are truncated. Changed examine() to work on original msg source (before-scan) if msg has to be stripped due to oversize. After scanning the truncated message the spamd headers are prepended to original message source and the resulting msg is further processed.