### PR TITLE
support multiple plugin directories

### DIFF
--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -134,7 +134,7 @@ class MainController(object):
 
             'plugindir': {
                 'section': 'main',
-                'description': "where should fuglu search for additional plugins",
+                'description': "comma separated list of directories in which fuglu searches for additional plugins and their dependencies",
                 'default': "",
             },
 
@@ -922,14 +922,14 @@ class MainController(object):
     def load_plugins(self):
         """load plugins defined in config"""
         allOK = True
-        plugdir = self.config.get('main', 'plugindir').strip()
-        if plugdir != "" and not os.path.isdir(plugdir):
-            self._logger().warning('Plugin directory %s not found' % plugdir)
-
-        if plugdir != "":
-            self._logger().debug('Searching for additional plugins in %s' % plugdir)
-            if plugdir not in sys.path:
-                sys.path.insert(0, plugdir)
+        plugindirs = self.config.get('main', 'plugindir').strip().split(',')
+        for plugindir in plugindirs:
+            if os.path.isdir(plugindir):
+                self._logger().debug('Searching for additional plugins in %s' % plugindir)
+                if plugindir not in sys.path:
+                    sys.path.insert(0, plugindir)
+            else:
+                self._logger().warning('Plugin directory %s not found' % plugindir)
 
         self._logger().debug('Module search path %s' % sys.path)
         self._logger().debug('Loading scanner plugins')


### PR DESCRIPTION
this PR changes the plugindir configuration option to support multiple commma separated directories

This allows for example to have a dedicated directory for plugin dependencies, but could also be handy for developers who might have a development dir in addition to the default /usr/local/fuglu/plugins

Note: the plugdummy tool already supports multiple plugin directories.