### PR TITLE
Logging for multiprocessing and reloading of main/logging config + Cache fix Py 3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ unittests:
   only:
     - master
     - python3
+    - reload
 
 unittests_py3:
   stage: test_py3
@@ -23,6 +24,7 @@ unittests_py3:
   only:
     - master
     - python3
+    - reload
 
 integrationtests:
   stage: test
@@ -35,6 +37,7 @@ integrationtests:
   only:
     - master
     - python3
+    - reload
 
 integrationtests_py3:
   stage: test_py3
@@ -47,6 +50,7 @@ integrationtests_py3:
   only:
     - master
     - python3
+    - reload
 
 
 # define RSYNC_TARGET in gitlab -> project domainmagic -> settings -> variables
@@ -62,6 +66,7 @@ buildfuglu:
   only:
     - master
     - python3
+    - reload
 
 buildfuglu_py3:
   stage: build_py3
@@ -74,3 +79,4 @@ buildfuglu_py3:
   only:
     - master
     - python3
+    - reload

--- a/fuglu/develop/docker/centos-7/start-services.sh
+++ b/fuglu/develop/docker/centos-7/start-services.sh
@@ -34,6 +34,9 @@ wait_for_file () {
 
 
 
+echo "update clamd virus definitions"
+freshclam
+
 createlog=1
 if [ "$1" = "nolog" ];  then
    echo "no log file will be created and no wait operation performed"

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -439,6 +439,8 @@ class MainController(object):
         self.debugconsole = False
         self._logQueue = logQueue
         self._logProcess = logProcess
+        self.configFileUpdates = None
+        self.logConfigFileUpdates = None
 
     @property
     def logQueue(self):

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -946,11 +946,11 @@ class MainController(object):
         plugindirs = self.config.get('main', 'plugindir').strip().split(',')
         for plugindir in plugindirs:
             if os.path.isdir(plugindir):
-                self._logger().debug('Searching for additional plugins in %s' % plugindir)
+                self.logger.debug('Searching for additional plugins in %s' % plugindir)
                 if plugindir not in sys.path:
                     sys.path.insert(0, plugindir)
             else:
-                self._logger().warning('Plugin directory %s not found' % plugindir)
+                self.logger.warning('Plugin directory %s not found' % plugindir)
 
         self.logger.debug('Module search path %s' % sys.path)
         self.logger.debug('Loading scanner plugins')

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -105,7 +105,7 @@ class MainController(object):
     appenders = []
     config = None
 
-    def __init__(self, config,logQueue):
+    def __init__(self, config,logQueue,logProcess=None):
         self.requiredvars = {
             # main section
             'identifier': {
@@ -438,6 +438,19 @@ class MainController(object):
         self.statsthread = None
         self.debugconsole = False
         self._logQueue = logQueue
+        self._logProcess = logProcess
+
+    @property
+    def logQueue(self):
+        return self._logQueue
+
+    @property
+    def logProcess(self):
+        return self._logProcess
+
+    @logProcess.setter
+    def logProcess(self,lProc):
+        self._logProcess = lProc
 
     def _logger(self):
         myclass = self.__class__.__name__

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -105,7 +105,7 @@ class MainController(object):
     appenders = []
     config = None
 
-    def __init__(self, config,logQueue,logProcess=None):
+    def __init__(self, config, logQueue, logProcessFacQueue=None):
         self.requiredvars = {
             # main section
             'identifier': {
@@ -438,7 +438,7 @@ class MainController(object):
         self.statsthread = None
         self.debugconsole = False
         self._logQueue = logQueue
-        self._logProcess = logProcess
+        self._logProcessFacQueue = logProcessFacQueue
         self.configFileUpdates = None
         self.logConfigFileUpdates = None
 
@@ -447,12 +447,12 @@ class MainController(object):
         return self._logQueue
 
     @property
-    def logProcess(self):
-        return self._logProcess
+    def logProcessFacQueue(self):
+        return self._logProcessFacQueue
 
-    @logProcess.setter
-    def logProcess(self,lProc):
-        self._logProcess = lProc
+    @logProcessFacQueue.setter
+    def logProcessFacQueue(self, lProc):
+        self._logProcessFacQueue = lProc
 
     def _logger(self):
         myclass = self.__class__.__name__

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -658,7 +658,7 @@ class MainController(object):
                     self.logger.info('Keep existing threadpool')
             else:
                 self.logger.info('Create new threadpool')
-                self._threadpool = self._start_threadpool()
+                self.threadpool = self._start_threadpool()
 
             # stop existing procpool
             if self.procpool is not None:

--- a/fuglu/src/fuglu/logtools.py
+++ b/fuglu/src/fuglu/logtools.py
@@ -126,9 +126,24 @@ def listener_process(configurer,queue):
     configurer.configure()
     root = logging.getLogger()
     root.info("Listener process started")
+    logLogger = logging.getLogger("LogListener")
+    if logLogger.propagate:
+        root.info("No special Log-logger")
+        logLogger = None
+    else:
+        root.info("Using special LogLogger")
+
     while True:
         try:
             record = queue.get()
+            if logLogger:
+                logLogger.debug("Approx queue size: %u, received record to process -> %s"%(queue.qsize(),record))
+
+            if queue.full():
+                root.error("QUEUE IS FULL!!!")
+                if logLogger:
+                    logLogger.error("QUEUE IS FULL!!!")
+
             if record is None:  # We send this as a sentinel to tell the listener to quit.
                 break
             logger = logging.getLogger(record.name)

--- a/fuglu/src/fuglu/logtools.py
+++ b/fuglu/src/fuglu/logtools.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import logging
 import logging.handlers
 import logging.config
-import fuglu.procpool
+import os
 import multiprocessing
 
 def logFactoryProcess(listenerQueue,logQueue):
@@ -195,7 +195,7 @@ def client_configurer(queue):
     root = logging.getLogger()
 
     numRootHandlers = len(root.handlers)
-    name = fuglu.procpool.createPIDinfo()
+    name = createPIDinfo()
 
     if numRootHandlers == 0:
         try:
@@ -279,3 +279,11 @@ class QueueHandlerPy3Copy(logging.Handler):
             self.enqueue(self.prepare(record))
         except Exception:
             self.handleError(record)
+
+
+def createPIDinfo():
+    infoString = ""
+    if hasattr(os, 'getppid'):  # only available on Unix
+        infoString += 'parent process: %u, ' % os.getppid()
+    infoString += 'process id: %u' % os.getpid()
+    return infoString

--- a/fuglu/src/fuglu/logtools.py
+++ b/fuglu/src/fuglu/logtools.py
@@ -1,0 +1,110 @@
+import logging
+import logging.handlers
+import logging.config
+import fuglu.procpool
+
+class logConfig(object):
+    """
+    Conig class to easily distinguish logging configuration for lint and production (from file)
+    """
+    def __init__(self,lint=False,logConfigFile=None):
+        """
+        Setup in lint mode of using a config file
+        Args:
+            lint (bool): enable lint mode which will print on the screen
+            logConfigFile (): load configuration from config file
+        """
+        assert (lint or logConfigFile)
+        assert not (lint and logConfigFile)
+
+        self._configFile = logConfigFile
+
+        self._lint = lint
+        if self._lint:
+            self.configure = self._configure4lint
+        elif self._configFile:
+            self.configure = self._configure
+        else:
+            raise Exception("Not implemented!")
+
+    def _configure4lint(self):
+        """
+        Configure for lint mode (output is on the screen, level is debug)
+        """
+        root = logging.getLogger()
+        console = logging.StreamHandler()
+        console.setLevel(logging.DEBUG)
+        # set a format which is simpler for console use
+        formatter = logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+        # tell the handler to use this format
+        console.setFormatter(formatter)
+        # add the handler to the root logger
+        root.addHandler(console)
+
+    def _configure(self):
+        """
+        Configure logging using log configuration file
+        """
+        root = logging.getLogger()
+        logging.config.fileConfig(self._configFile)
+        print(str(logging.Logger.manager.loggerDict))
+
+
+def listener_process(queue, configurer):
+    """
+    This is the listener process top-level loop: wait for logging events
+    (LogRecords) on the queue and handle them, quit when you get a None for a
+    LogRecord.
+
+    Args:
+        queue (multiprocessing.Queue): queue where to listen for log messages
+        configurer (logConfig): instance lof logConfig class setting up logging on configure call
+
+    Returns:
+
+    """
+    configurer.configure()
+    root = logging.getLogger()
+    root.info("Listener process started")
+    while True:
+        try:
+            record = queue.get()
+            if record is None:  # We send this as a sentinel to tell the listener to quit.
+                break
+            #print("listener_process: "+str(record))
+            logger = logging.getLogger(record.name)
+            logger.handle(record)  # No level or filter logic applied - just do it!
+        except KeyboardInterrupt:
+            print("Listener process received KeyboardInterrupt")
+            break
+        except Exception:
+            import sys, traceback
+            print('Whoops! Problem:', file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+    root.info("Listener process stopped")
+
+def client_configurer(queue):
+    """
+    The client configuration is done at the start of the worker process run.
+    Note that on Windows you can't rely on fork semantics, so each process
+    will run the logging configuration code when it starts.
+
+    Args:
+        queue (multiprocessing.Queue): queue where to send log messages
+
+    """
+    root = logging.getLogger()
+
+    numRootHandlers = len(root.handlers)
+    name = fuglu.procpool.createPIDinfo()
+
+    if numRootHandlers == 0:
+        h = logging.handlers.QueueHandler(queue)  # Just the one handler needed
+        root.addHandler(h)
+        # send all messages, for demo; no other level or filter logic applied.
+        root.setLevel(logging.DEBUG)
+        root.info("(%s) Queue handler added to root logger" % name)
+    else:
+        # on linux config is taken from father process automatically
+        root.info("(%s) Queue handler already present in root logger" % name)
+

--- a/fuglu/src/fuglu/plugins/fprot.py
+++ b/fuglu/src/fuglu/plugins/fprot.py
@@ -143,6 +143,7 @@ Tags:
 
     def _parse_result(self, result):
         dr = {}
+        result = force_uString(result)
         for line in result.strip().split('\n'):
             m = self.pattern.match(force_bString(line))
             if m == None:

--- a/fuglu/src/fuglu/plugins/fprot.py
+++ b/fuglu/src/fuglu/plugins/fprot.py
@@ -143,8 +143,8 @@ Tags:
 
     def _parse_result(self, result):
         dr = {}
-        for line in result.strip().split(b'\n'):
-            m = self.pattern.match(line)
+        for line in result.strip().split('\n'):
+            m = self.pattern.match(force_bString(line))
             if m == None:
                 self._logger().error(
                     'Could not parse line from f-prot: %s' % line)

--- a/fuglu/src/fuglu/procpool.py
+++ b/fuglu/src/fuglu/procpool.py
@@ -27,14 +27,6 @@ import pickle
 from fuglu.stats import Statskeeper, StatDelta
 import fuglu.logtools
 import threading
-import os
-
-def createPIDinfo():
-    infoString = ""
-    if hasattr(os, 'getppid'):  # only available on Unix
-        infoString += 'parent process: %u, ' % os.getppid()
-    infoString += 'process id: %u' % os.getpid()
-    return infoString
 
 class ProcManager(object):
     def __init__(self, logQueue, numprocs = None, queuesize=100, config = None):
@@ -142,7 +134,7 @@ def fuglu_process_worker(queue, config, shared_state,child_to_server_messages, l
     logging.basicConfig(level=logging.DEBUG)
     workerstate = WorkerStateWrapper(shared_state,'loading configuration')
     logger = logging.getLogger('fuglu.process')
-    logger.debug("New worker: %s" % createPIDinfo())
+    logger.debug("New worker: %s" % fuglu.logtools.createPIDinfo())
 
     # load config and plugins
     controller = fuglu.core.MainController(config,logQueue)
@@ -157,15 +149,15 @@ def fuglu_process_worker(queue, config, shared_state,child_to_server_messages, l
     stats = Statskeeper()
     stats.stat_listener_callback.append(lambda event: child_to_server_messages.put(event.as_message()))
 
-    logger.debug("%s: Enter service loop..." % createPIDinfo())
+    logger.debug("%s: Enter service loop..." % fuglu.logtools.createPIDinfo())
 
     try:
         while True:
             workerstate.workerstate = 'waiting for task'
-            logger.debug("%s: Child process waiting for task" % createPIDinfo())
+            logger.debug("%s: Child process waiting for task" % fuglu.logtools.createPIDinfo())
             task = queue.get()
             if task is None: # poison pill
-                logger.debug("%s: Child process received poison pill - shut down" % createPIDinfo())
+                logger.debug("%s: Child process received poison pill - shut down" % fuglu.logtools.createPIDinfo())
                 try:
                     # it might be possible it does not work to properly set the workerstate
                     # since this is a shared variable -> prevent exceptions
@@ -175,7 +167,7 @@ def fuglu_process_worker(queue, config, shared_state,child_to_server_messages, l
                 finally:
                     return
             workerstate.workerstate = 'starting scan session'
-            logger.debug("%s: Child process starting scan session" % createPIDinfo())
+            logger.debug("%s: Child process starting scan session" % fuglu.logtools.createPIDinfo())
             pickled_socket, handler_modulename, handler_classname = task
             sock = pickle.loads(pickled_socket)
             handler_class = getattr(importlib.import_module(handler_modulename), handler_classname)

--- a/fuglu/src/fuglu/protocolbase.py
+++ b/fuglu/src/fuglu/protocolbase.py
@@ -111,7 +111,7 @@ class BasicTCPServer(object):
                 self.logger.debug('Incoming connection from %s' % str(addr))
                 if self.controller.threadpool:
                     # this will block if queue is full
-                    threadpool.add_task(engine)
+                    self.controller.threadpool.add_task(engine)
                 elif self.controller.procpool:
                     # in multi processing, the other process manages configs and plugins itself, we only pass the minimum required information:
                     # a pickled version of the socket (this is no longer required in python 3.4, but in python 2 the multiprocessing queue can not handle sockets

--- a/fuglu/src/fuglu/protocolbase.py
+++ b/fuglu/src/fuglu/protocolbase.py
@@ -83,9 +83,14 @@ class BasicTCPServer(object):
             pass
 
     def serve(self):
-        controller = self.controller
-        threadpool = self.controller.threadpool
-        procpool = self.controller.procpool
+        # Important:
+        # -> do NOT create local variables which are copies of member variables like
+        # controller = self.controller
+        # threadpool = self.controller.threadpool
+        # procpool = self.controller.procpool
+        # Since thes variables might change while in the stayalive loop the process would get stuck,
+        # example: when sending SIGHUP which might recreate the processor pool or threads pool
+        #          which would then still point to the wrong (old) memory location and is therefore not served anymore
 
         threading.currentThread().name = '%s Server on Port %s' % (
             self.protohandlerclass.protoname, self.port)
@@ -100,21 +105,21 @@ class BasicTCPServer(object):
                 sock,addr = nsd
                 if not self.stayalive:
                     break
-                ph = self.protohandlerclass(sock, controller.config)
+                ph = self.protohandlerclass(sock, self.controller.config)
                 engine = SessionHandler(
-                    ph, controller.config, controller.prependers, controller.plugins, controller.appenders)
+                    ph, self.controller.config, self.controller.prependers, self.controller.plugins, self.controller.appenders)
                 self.logger.debug('Incoming connection from %s' % str(addr))
-                if threadpool:
+                if self.controller.threadpool:
                     # this will block if queue is full
                     threadpool.add_task(engine)
-                elif procpool:
+                elif self.controller.procpool:
                     # in multi processing, the other process manages configs and plugins itself, we only pass the minimum required information:
                     # a pickled version of the socket (this is no longer required in python 3.4, but in python 2 the multiprocessing queue can not handle sockets
                     # see https://stackoverflow.com/questions/36370724/python-passing-a-tcp-socket-object-to-a-multiprocessing-queue
                     handler_classname = self.protohandlerclass.__name__
                     handler_modulename = self.protohandlerclass.__module__
                     task = forking_dumps(sock),handler_modulename, handler_classname
-                    procpool.add_task(task)
+                    self.controller.procpool.add_task(task)
                 else:
                     engine.handlesession()
             except Exception as e:

--- a/fuglu/src/fuglu/protocolbase.py
+++ b/fuglu/src/fuglu/protocolbase.py
@@ -25,6 +25,7 @@ try:
 except ImportError:
     # Python 3
     from io import BytesIO as StringIO
+from fuglu.procpool import createPIDinfo
 
 class ProtocolHandler(object):
     protoname = 'UNDEFINED'
@@ -58,6 +59,8 @@ class BasicTCPServer(object):
         self.logger = logging.getLogger("fuglu.incoming.%s" % port)
         self.logger.debug('Starting incoming Server on Port %s, protocol=%s' % (
             port, self.protohandlerclass.protoname))
+        self.logger.debug('Incoming server process info:  %s' % createPIDinfo())
+        self.logger.debug('(%s) Logger id is %s' % (createPIDinfo(),id(self)))
         self.port = port
         self.controller = controller
         self.stayalive = True
@@ -108,7 +111,7 @@ class BasicTCPServer(object):
                 ph = self.protohandlerclass(sock, self.controller.config)
                 engine = SessionHandler(
                     ph, self.controller.config, self.controller.prependers, self.controller.plugins, self.controller.appenders)
-                self.logger.debug('Incoming connection from %s' % str(addr))
+                self.logger.debug('(%s) Incoming connection  [incoming server port: %s, prot: %s]' % (createPIDinfo(),self.port,self.protohandlerclass.protoname))
                 if self.controller.threadpool:
                     # this will block if queue is full
                     self.controller.threadpool.add_task(engine)

--- a/fuglu/src/fuglu/protocolbase.py
+++ b/fuglu/src/fuglu/protocolbase.py
@@ -25,7 +25,8 @@ try:
 except ImportError:
     # Python 3
     from io import BytesIO as StringIO
-from fuglu.procpool import createPIDinfo
+from fuglu.logtools import createPIDinfo
+
 
 class ProtocolHandler(object):
     protoname = 'UNDEFINED'

--- a/fuglu/src/fuglu/shared.py
+++ b/fuglu/src/fuglu/shared.py
@@ -1345,7 +1345,7 @@ class Cache(object):
 
                 cleancount=0
 
-                for key in self.cache.keys()[:]:
+                for key in set(self.cache.keys()):
                     obj,instime=self.cache[key]
                     if now-instime>self.cachetime:
                         del self.cache[key]

--- a/fuglu/src/fuglu/shared.py
+++ b/fuglu/src/fuglu/shared.py
@@ -1387,11 +1387,8 @@ class CacheSingleton(object):
         return getattr(self.instance, name)
 
 
-#DEFAULTCACHE=None
-#def get_default_cache():
-#    global DEFAULTCACHE
-#    if DEFAULTCACHE is None:
-#        DEFAULTCACHE=Cache()
-#    return DEFAULTCACHE
 def get_default_cache():
+    """
+    Function to get processor unique Cache Singleton
+    """
     return CacheSingleton()

--- a/fuglu/src/fuglu/threadpool.py
+++ b/fuglu/src/fuglu/threadpool.py
@@ -123,6 +123,9 @@ class ThreadPool(threading.Thread):
             time.sleep(self.checkinterval)
         for worker in self.workers:
             worker.stayalive = False
+        for worker in self.workers:
+            worker.join(120)
+
         del self.workers
         self.logger.info('Threadpool shut down')
 
@@ -131,6 +134,7 @@ class ThreadPool(threading.Thread):
         for bla in range(0, num):
             worker = self.workers[0]
             worker.stayalive = False
+            worker.join(120)
             del self.workers[0]
 
     def _add_worker(self, num=1):

--- a/fuglu/src/startscript/fuglu
+++ b/fuglu/src/startscript/fuglu
@@ -43,7 +43,6 @@ import time
 import hashlib
 
 controller = None
-logProcess = None
 
 theconfigfile = '/etc/fuglu/fuglu.conf'
 dconfdir = '/etc/fuglu/conf.d'
@@ -69,7 +68,7 @@ def reloadconfig():
                      "No changes will be applied...!\nSend SIGHUP to the main process!")
         return
 
-    if controller.logProcess is None:
+    if controller.logProcessFacQueue is None:
         logger.error("No log process in controller -> This is not the main process!\n"
                      "No changes will be applied...!\nSend SIGHUP to the main process!")
         return
@@ -79,56 +78,18 @@ def reloadconfig():
 
     configFileUpdates    = getConfigFileUpdatesDict(theconfigfile,dconfdir)
     logConfigFileUpdates = getLogConfigFileUpdatesDict(theloggingfile)
-    print("logConfigFileUpdatesDict (old)")
-    print(str(controller.logConfigFileUpdates))
-    print("logConfigFileUpdatesDict (new)")
-    print(str(logConfigFileUpdates))
-    print("Log config has changes: %s" % str(logConfigFileUpdates != controller.logConfigFileUpdates))
-    print("configFileUpdatesDict (old)")
-    print(str(controller.configFileUpdates))
-    print("configFileUpdatesDict (new)")
-    print(str(configFileUpdates))
-    print("Main config has changes: %s" % str(configFileUpdates != controller.configFileUpdates))
+
     logger.info("Log config has changes: %s" % str(logConfigFileUpdates != controller.logConfigFileUpdates))
     logger.info("Main config has changes: %s" % str(configFileUpdates != controller.configFileUpdates))
 
     if logConfigFileUpdates != controller.logConfigFileUpdates:
         # save back log config file dict for later use
         controller.logConfigFileUpdates = logConfigFileUpdates
+
         logger.info("Create new log process with new configuration")
-
-        #---
-        # stop logger process
-        #---
-        logQueue = controller.logQueue
-        logProcess = controller.logProcess
-
-        try:
-            newLogConfigure = fuglu.logtools.logConfig(logQueue,logConfigFile=theloggingfile)
-        except Exception as e:
-            logging.exception(e)
-            logging.error("Error in the log file, noe applying any change!")
-            return
-
-        # try to close the old logger
-        try:
-            logQueue.put_nowait(None)
-            logProcess.join(10) # wait 10 seconds max
-        except Exception:
-            logger.error("Could not close old logger!")
-            time.sleep(2)
-            pass
-
-        #--
-        # start new process handling logging queue
-        # this process uses now an updated version of the log file
-        #--
-        logProcess = multiprocessing.Process(target=fuglu.logtools.listener_process,
-                                             args=(newLogConfigure,))
-        logProcess.start()
-
-        # save logging process back to controller
-        controller.logProcess = logProcess
+        logProcessFacQueue = controller.logProcessFacQueue
+        newLogConfigure = fuglu.logtools.logConfig(logConfigFile=theloggingfile)
+        logProcessFacQueue.put(newLogConfigure)
 
     if configFileUpdates != controller.configFileUpdates:
         logger.info('Reloading configuration')
@@ -292,6 +253,7 @@ except:
 # all threads/processes write to the logQueue which
 # will be handled by a separate process
 logQueue   = multiprocessing.Queue(-1)
+logFactoryQueue = multiprocessing.Queue(-1)
 
 # setup a process which handles logging messages
 if lint:
@@ -301,26 +263,34 @@ if lint:
     print("----------", fc.strcolor("LINT MODE",
                                     (fc.MODE["blink"], fc.FG["magenta"])), "----------")
 
-    logConfigure = fuglu.logtools.logConfig(logQueue,lint=True)
+    logConfigure = fuglu.logtools.logConfig(lint=True)
 
 else:
-    logConfigure = fuglu.logtools.logConfig(logQueue,logConfigFile=theloggingfile)
+    logConfigure = fuglu.logtools.logConfig(logConfigFile=theloggingfile)
 
 #--
 # start process handling logging queue
 #--
-logProcess = multiprocessing.Process(target=fuglu.logtools.listener_process,
-                                     args=(logConfigure,))
-logProcess.start()
+logProcessFactory = multiprocessing.Process(target=fuglu.logtools.logFactoryProcess,
+                                     args=(logFactoryQueue,logQueue))
+#logProcessFactory.daemon = True
+logProcessFactory.start()
 
-# setup this main thread to send messages to the log queue (which is handled by the logProcess)
-fuglu.logtools.client_configurer(logConfigure.queue)
+# now create a log - listener process
+logFactoryQueue.put(logConfigure)
 
+# setup this main thread to send messages to the log queue 
+# (which is handled by the logger process created by the logProcessFactory)
+fuglu.logtools.client_configurer(logQueue)
+
+#===                      ===#
+#= Now logging is available =#
+#===                      ===#
 baselogger = logging.getLogger()
 baselogger.info("FuGLU Version %s starting up" % FUGLU_VERSION)
 
 # instantiate the MainController and load default configuration
-controller = MainController(config,logConfigure.queue,logProcess)
+controller = MainController(config,logQueue,logFactoryQueue)
 controller.configFileUpdates = getConfigFileUpdatesDict(theconfigfile,dconfdir)
 controller.logConfigFileUpdates = getLogConfigFileUpdatesDict(theloggingfile)
 controller.propagate_core_defaults()
@@ -356,11 +326,10 @@ else:
 
 
 #---
-# stop logger process
+# stop logger factory & process
 #---
 try:
-    controller.logQueue.put_nowait(None)
-    # wait 2 minutes max
-    controller.logProcess.join(120)
-except Exception:
-    pass
+    logFactoryQueue.put_nowait(None)
+    logProcessFactory.join(120)
+except Exception as e:
+    logProcessFactory.terminate()

--- a/fuglu/src/startscript/fuglu
+++ b/fuglu/src/startscript/fuglu
@@ -23,6 +23,7 @@ try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
+
 from fuglu import FUGLU_VERSION
 from fuglu.daemon import DaemonStuff
 import logging
@@ -36,6 +37,8 @@ import os
 import pwd
 import grp
 import optparse
+import fuglu.logtools
+import multiprocessing
 
 controller = None
 
@@ -53,8 +56,9 @@ def reloadconfig():
     logger = logging.getLogger('fuglu')
     if controller:
         if controller.threadpool is None and controller.procpool is None:
-            logger.error("No process/threadpool -> This is not the main process!\n"
-                         "No changes will be applied...!\nSend SIGHUP to the main process!")
+            logger.error("""No process/threadpool -> This is not the main process!
+                          \nNo changes will be applied...!\nSend SIGHUP to the main process!
+                          \nCurrent controller object : %s, %s""" % (id(controller),controller.__repr__()))
             return
     else:
         logger.error("No controller -> This is not the main process!\n"
@@ -178,31 +182,42 @@ except:
           (running_user, running_group, str(err)))
 
 
+#--
 # set up logging
+#--
+
+# all threads/processes write to the logQueue which
+# will be handled by a separate process
+logQueue   = multiprocessing.Queue(-1)
+
+# setup a process which handles logging messages
 if lint:
-    # define a Handler which writes INFO messages or higher to the sys.stderr
-    console = logging.StreamHandler()
-    console.setLevel(logging.DEBUG)
-    # set a format which is simpler for console use
-    formatter = logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
-    # tell the handler to use this format
-    console.setFormatter(formatter)
-    # add the handler to the root logger
-    logging.getLogger('').addHandler(console)
     fc = fuglu.funkyconsole.FunkyConsole()
     print(fc.strcolor("Fuglu", "yellow"), end=' ')
     print(fc.strcolor(FUGLU_VERSION, "green"))
     print("----------", fc.strcolor("LINT MODE",
                                     (fc.MODE["blink"], fc.FG["magenta"])), "----------")
 
-else:
-    logging.config.fileConfig(theloggingfile)
+    logConfigure = fuglu.logtools.logConfig(lint=True)
 
-baselogger = logging.getLogger('')
+else:
+    logConfigure = fuglu.logtools.logConfig(logConfigFile=theloggingfile)
+
+#--
+# start process handling logging queue
+#--
+logProcess = multiprocessing.Process(target=fuglu.logtools.listener_process,
+                                     args=(logQueue, logConfigure))
+logProcess.start()
+
+# setup this main thread to send messages to the log queue (which is handled by the logProcess)
+fuglu.logtools.client_configurer(logQueue)
+
+baselogger = logging.getLogger()
 baselogger.info("FuGLU Version %s starting up" % FUGLU_VERSION)
 
 # instantiate the MainController and load default configuration
-controller = MainController(config)
+controller = MainController(config,logQueue)
 controller.propagate_core_defaults()
 
 
@@ -233,3 +248,13 @@ else:
     if console:
         controller.debugconsole = True
     controller.startup()
+
+
+#---
+# stop logger process
+#---
+try:
+    logQueue.put_nowait(None)
+    logProcess.join()
+except Exception:
+    pass

--- a/fuglu/src/startscript/fuglu
+++ b/fuglu/src/startscript/fuglu
@@ -40,6 +40,7 @@ import optparse
 import fuglu.logtools
 import multiprocessing
 import time
+import hashlib
 
 controller = None
 logProcess = None
@@ -73,79 +74,110 @@ def reloadconfig():
                      "No changes will be applied...!\nSend SIGHUP to the main process!")
         return
 
-    #logger.info('Reloading logging configuration')
+    assert controller.logFonfigFileUpdates is not None
+    assert controller.configFileUpdates is not None
 
-    #---
-    # stop logger process
-    #---
-    logQueue = controller.logQueue
-    logProcess = controller.logProcess
+    configFileUpdates    = getConfigFileUpdatesDict(theconfigfile,dconfdir)
+    logConfigFileUpdates = getLogConfigFileUpdatesDict(theloggingfile)
+    logger.info("Log config has changes: %s" % str(logConfigFileUpdates == controller.logConfigFileUpdates))
+    logger.info("Main config has changes: %s" % str(configFileUpdates == controller.configFileUpdates))
 
-    try:
-        newLogConfigure = fuglu.logtools.logConfig(logQueue,logConfigFile=theloggingfile)
-    except Exception as e:
-        logging.exception(e)
-        logging.error("Error in the log file, noe applying any change!")
-        return
+    if logConfigFileUpdates != controller.logConfigFileUpdates:
+        # save back log config file dict for later use
+        controller.logConfigFileUpdates = logConfigFileUpdates
+        logger.info("Create new log process with new configuration")
 
-    # try to close the old logger
-    try:
-        logQueue.put_nowait(None)
-        logProcess.join(10) # wait 10 seconds max
-    except Exception:
-        logger.error("Could not close old logger!")
-        time.sleep(2)
-        pass
+        #---
+        # stop logger process
+        #---
+        logQueue = controller.logQueue
+        logProcess = controller.logProcess
 
-    #--
-    # start new process handling logging queue
-    # this process uses now an updated version of the log file
-    #--
-    logProcess = multiprocessing.Process(target=fuglu.logtools.listener_process,
-                                         args=(newLogConfigure,))
-    logProcess.start()
+        try:
+            newLogConfigure = fuglu.logtools.logConfig(logQueue,logConfigFile=theloggingfile)
+        except Exception as e:
+            logging.exception(e)
+            logging.error("Error in the log file, noe applying any change!")
+            return
 
-    # save logging process back to controller
-    controller.logProcess = logProcess
+        # try to close the old logger
+        try:
+            logQueue.put_nowait(None)
+            logProcess.join(10) # wait 10 seconds max
+        except Exception:
+            logger.error("Could not close old logger!")
+            time.sleep(2)
+            pass
 
-    logger.info('Reloading configuration')
-    newconfig = configparser.RawConfigParser()
-    with open(theconfigfile) as fp:
-        newconfig.readfp(fp)
+        #--
+        # start new process handling logging queue
+        # this process uses now an updated version of the log file
+        #--
+        logProcess = multiprocessing.Process(target=fuglu.logtools.listener_process,
+                                             args=(newLogConfigure,))
+        logProcess.start()
 
-    identifier = "no identifier given"
-    if newconfig.has_option('main', 'identifier'):
-        identifier = newconfig.get('main', 'identifier')
+        # save logging process back to controller
+        controller.logProcess = logProcess
 
-    # load conf.d
-    if os.path.isdir(dconfdir):
-        filelist = os.listdir(dconfdir)
-        configfiles = [
-            dconfdir + '/' + c for c in filelist if c.endswith('.conf')]
-        logger.debug('Conffiles in %s: %s' % (dconfdir, configfiles))
-        readfiles = newconfig.read(configfiles)
-        logger.debug('Read additional files: %s' % (readfiles))
+    if configFileUpdates != controller.configFileUpdates:
+        logger.info('Reloading configuration')
 
-    logger.info('Reload config complete. Current configuration:%s' %
-                identifier)
-    controller.config = newconfig
-    controller.propagate_core_defaults()
+        # save back config file dict for later use
+        controller.configFileUpdates = configFileUpdates
+        newconfig = configparser.RawConfigParser()
+        with open(theconfigfile) as fp:
+            newconfig.readfp(fp)
 
-    logger.info('Reloading plugins...')
-    ok = controller.load_plugins()
-    if ok:
-        logger.info('Plugin reload completed')
-    else:
-        logger.error('Plugin reload failed')
+        identifier = "no identifier given"
+        if newconfig.has_option('main', 'identifier'):
+            identifier = newconfig.get('main', 'identifier')
 
-    controller.propagate_plugin_defaults()
+        # load conf.d
+        if os.path.isdir(dconfdir):
+            filelist = os.listdir(dconfdir)
+            configfiles = [
+                dconfdir + '/' + c for c in filelist if c.endswith('.conf')]
+            logger.debug('Conffiles in %s: %s' % (dconfdir, configfiles))
+            readfiles = newconfig.read(configfiles)
+            logger.debug('Read additional files: %s' % (readfiles))
 
-    controller.reload()
+        logger.info('Reload config complete. Current configuration:%s' %
+                    identifier)
+        controller.config = newconfig
+        controller.propagate_core_defaults()
+
+        logger.info('Reloading plugins...')
+        ok = controller.load_plugins()
+        if ok:
+            logger.info('Plugin reload completed')
+        else:
+            logger.error('Plugin reload failed')
+
+        controller.propagate_plugin_defaults()
+
+        controller.reload()
 
 
 def sighup(signum, frame):
     """handle sighup to reload config"""
     reloadconfig()
+
+def getConfigFileUpdatesDict(configfilename,dconfigFileDir):
+    configFileUpdates = {}
+    configFileUpdates[configfilename] = hashlib.md5(configfilename).hexdigest()
+    # load conf.d
+    if dconfigFileDir and os.path.isdir(dconfigFileDir):
+        filelist = os.listdir(dconfigFileDir)
+        configfiles = [dconfigFileDir + '/' + c for c in filelist if c.endswith('.conf')]
+        for filename in configfiles:
+            configFileUpdates[filename] = hashlib.md5(filename).hexdigest()
+    return configFileUpdates
+
+def getLogConfigFileUpdatesDict(logConfFile):
+    logConfigFileUpdates = {}
+    logConfigFileUpdates[logConfFile] = hashlib.md5(logConfFile).hexdigest()
+    return logConfigFileUpdates
 
 lint = False
 debugmsg = False
@@ -261,6 +293,8 @@ baselogger.info("FuGLU Version %s starting up" % FUGLU_VERSION)
 
 # instantiate the MainController and load default configuration
 controller = MainController(config,logConfigure.queue,logProcess)
+controller.configFileUpdates = getConfigFileUpdatesDict(theconfigfile,dconfdir)
+controller.logConfigFileUpdates = getLogConfigFileUpdatesDict(theloggingfile)
 controller.propagate_core_defaults()
 
 

--- a/fuglu/src/startscript/fuglu
+++ b/fuglu/src/startscript/fuglu
@@ -82,6 +82,8 @@ def reloadconfig():
     logger.info("Log config has changes: %s" % str(logConfigFileUpdates != controller.logConfigFileUpdates))
     logger.info("Main config has changes: %s" % str(configFileUpdates != controller.configFileUpdates))
 
+    logger.info('Number of messages in logging queue: %u'%controller.logQueue.qsize())
+
     if logConfigFileUpdates != controller.logConfigFileUpdates:
         # save back log config file dict for later use
         controller.logConfigFileUpdates = logConfigFileUpdates
@@ -90,6 +92,7 @@ def reloadconfig():
         logProcessFacQueue = controller.logProcessFacQueue
         newLogConfigure = fuglu.logtools.logConfig(logConfigFile=theloggingfile)
         logProcessFacQueue.put(newLogConfigure)
+
 
     if configFileUpdates != controller.configFileUpdates:
         logger.info('Reloading configuration')

--- a/fuglu/src/startscript/fuglu
+++ b/fuglu/src/startscript/fuglu
@@ -39,8 +39,10 @@ import grp
 import optparse
 import fuglu.logtools
 import multiprocessing
+import time
 
 controller = None
+logProcess = None
 
 theconfigfile = '/etc/fuglu/fuglu.conf'
 dconfdir = '/etc/fuglu/conf.d'
@@ -53,6 +55,7 @@ logging.custom_handlers = loghandlers
 
 def reloadconfig():
     """reload configuration file"""
+
     logger = logging.getLogger('fuglu')
     if controller:
         if controller.threadpool is None and controller.procpool is None:
@@ -64,6 +67,46 @@ def reloadconfig():
         logger.error("No controller -> This is not the main process!\n"
                      "No changes will be applied...!\nSend SIGHUP to the main process!")
         return
+
+    if controller.logProcess is None:
+        logger.error("No log process in controller -> This is not the main process!\n"
+                     "No changes will be applied...!\nSend SIGHUP to the main process!")
+        return
+
+    #logger.info('Reloading logging configuration')
+
+    #---
+    # stop logger process
+    #---
+    logQueue = controller.logQueue
+    logProcess = controller.logProcess
+
+    try:
+        newLogConfigure = fuglu.logtools.logConfig(logQueue,logConfigFile=theloggingfile)
+    except Exception as e:
+        logging.exception(e)
+        logging.error("Error in the log file, noe applying any change!")
+        return
+
+    # try to close the old logger
+    try:
+        logQueue.put_nowait(None)
+        logProcess.join(10) # wait 10 seconds max
+    except Exception:
+        logger.error("Could not close old logger!")
+        time.sleep(2)
+        pass
+
+    #--
+    # start new process handling logging queue
+    # this process uses now an updated version of the log file
+    #--
+    logProcess = multiprocessing.Process(target=fuglu.logtools.listener_process,
+                                         args=(newLogConfigure,))
+    logProcess.start()
+
+    # save logging process back to controller
+    controller.logProcess = logProcess
 
     logger.info('Reloading configuration')
     newconfig = configparser.RawConfigParser()
@@ -198,26 +241,26 @@ if lint:
     print("----------", fc.strcolor("LINT MODE",
                                     (fc.MODE["blink"], fc.FG["magenta"])), "----------")
 
-    logConfigure = fuglu.logtools.logConfig(lint=True)
+    logConfigure = fuglu.logtools.logConfig(logQueue,lint=True)
 
 else:
-    logConfigure = fuglu.logtools.logConfig(logConfigFile=theloggingfile)
+    logConfigure = fuglu.logtools.logConfig(logQueue,logConfigFile=theloggingfile)
 
 #--
 # start process handling logging queue
 #--
 logProcess = multiprocessing.Process(target=fuglu.logtools.listener_process,
-                                     args=(logQueue, logConfigure))
+                                     args=(logConfigure,))
 logProcess.start()
 
 # setup this main thread to send messages to the log queue (which is handled by the logProcess)
-fuglu.logtools.client_configurer(logQueue)
+fuglu.logtools.client_configurer(logConfigure.queue)
 
 baselogger = logging.getLogger()
 baselogger.info("FuGLU Version %s starting up" % FUGLU_VERSION)
 
 # instantiate the MainController and load default configuration
-controller = MainController(config,logQueue)
+controller = MainController(config,logConfigure.queue,logProcess)
 controller.propagate_core_defaults()
 
 
@@ -254,7 +297,8 @@ else:
 # stop logger process
 #---
 try:
-    logQueue.put_nowait(None)
-    logProcess.join()
+    controller.logQueue.put_nowait(None)
+    # wait 2 minutes max
+    controller.logProcess.join(120)
 except Exception:
     pass

--- a/fuglu/src/startscript/fuglu
+++ b/fuglu/src/startscript/fuglu
@@ -74,13 +74,23 @@ def reloadconfig():
                      "No changes will be applied...!\nSend SIGHUP to the main process!")
         return
 
-    assert controller.logFonfigFileUpdates is not None
+    assert controller.logConfigFileUpdates is not None
     assert controller.configFileUpdates is not None
 
     configFileUpdates    = getConfigFileUpdatesDict(theconfigfile,dconfdir)
     logConfigFileUpdates = getLogConfigFileUpdatesDict(theloggingfile)
-    logger.info("Log config has changes: %s" % str(logConfigFileUpdates == controller.logConfigFileUpdates))
-    logger.info("Main config has changes: %s" % str(configFileUpdates == controller.configFileUpdates))
+    print("logConfigFileUpdatesDict (old)")
+    print(str(controller.logConfigFileUpdates))
+    print("logConfigFileUpdatesDict (new)")
+    print(str(logConfigFileUpdates))
+    print("Log config has changes: %s" % str(logConfigFileUpdates != controller.logConfigFileUpdates))
+    print("configFileUpdatesDict (old)")
+    print(str(controller.configFileUpdates))
+    print("configFileUpdatesDict (new)")
+    print(str(configFileUpdates))
+    print("Main config has changes: %s" % str(configFileUpdates != controller.configFileUpdates))
+    logger.info("Log config has changes: %s" % str(logConfigFileUpdates != controller.logConfigFileUpdates))
+    logger.info("Main config has changes: %s" % str(configFileUpdates != controller.configFileUpdates))
 
     if logConfigFileUpdates != controller.logConfigFileUpdates:
         # save back log config file dict for later use
@@ -164,20 +174,38 @@ def sighup(signum, frame):
     reloadconfig()
 
 def getConfigFileUpdatesDict(configfilename,dconfigFileDir):
-    configFileUpdates = {}
-    configFileUpdates[configfilename] = hashlib.md5(configfilename).hexdigest()
+    configfiles = [configfilename]
     # load conf.d
     if dconfigFileDir and os.path.isdir(dconfigFileDir):
         filelist = os.listdir(dconfigFileDir)
-        configfiles = [dconfigFileDir + '/' + c for c in filelist if c.endswith('.conf')]
-        for filename in configfiles:
-            configFileUpdates[filename] = hashlib.md5(filename).hexdigest()
+        configfiles.extend([dconfigFileDir + '/' + c for c in filelist if c.endswith('.conf')])
+
+    hashlist = createMD5(configfiles)
+    configFileUpdates = dict(zip(configfiles, hashlist))
     return configFileUpdates
 
 def getLogConfigFileUpdatesDict(logConfFile):
     logConfigFileUpdates = {}
-    logConfigFileUpdates[logConfFile] = hashlib.md5(logConfFile).hexdigest()
+    logConfigFileUpdates[logConfFile] = createMD5([logConfFile])[0]
     return logConfigFileUpdates
+
+
+def hash_bytestr_iter(bytesiter, hasher, ashexstr=False):
+    for block in bytesiter:
+        hasher.update(block)
+    return (hasher.hexdigest() if ashexstr else hasher.digest())
+
+def file_as_blockiter(afile, blocksize=65536):
+    with afile:
+        block = afile.read(blocksize)
+        while len(block) > 0:
+            yield block
+            block = afile.read(blocksize)
+
+
+def createMD5(fnamelst):
+    return [(fname, hash_bytestr_iter(file_as_blockiter(open(fname, 'rb')), hashlib.md5()))
+        for fname in fnamelst]
 
 lint = False
 debugmsg = False

--- a/fuglu/tests/integration/endtoend_test.py
+++ b/fuglu/tests/integration/endtoend_test.py
@@ -40,7 +40,7 @@ class AllpluginTestCase(unittest.TestCase):
         config.set('main', 'disablebounces', '1')
         guess_clamav_socket(config)
 
-        self.mc = MainController(config)
+        self.mc = MainController(config,None)
         self.tempfiles = []
 
     def tearDown(self):
@@ -94,7 +94,7 @@ class EndtoEndTestTestCase(unittest.TestCase):
             'main', 'controlport', str(EndtoEndTestTestCase.FUGLUCONTROL_PORT))
         guess_clamav_socket(self.config)
         # init core
-        self.mc = MainController(self.config)
+        self.mc = MainController(self.config,None)
 
         # start listening smtp dummy server to get fuglus answer
         self.smtp = DummySMTPServer(
@@ -180,7 +180,7 @@ class DKIMTestCase(unittest.TestCase):
         guess_clamav_socket(self.config)
 
         # init core
-        self.mc = MainController(self.config)
+        self.mc = MainController(self.config, None)
 
         # start listening smtp dummy server to get fuglus answer
         self.smtp = DummySMTPServer(self.config, self.config.getint(
@@ -257,7 +257,7 @@ class SMIMETestCase(unittest.TestCase):
         guess_clamav_socket(self.config)
 
         # init core
-        self.mc = MainController(self.config)
+        self.mc = MainController(self.config,None)
 
         # start listening smtp dummy server to get fuglus answer
         self.smtp = DummySMTPServer(


### PR DESCRIPTION
- Python 3 fix for using Cache
- separate process to handle log-messages (py 2/3) using a queue for the log messages
- bugfix for switching between threadpool and processpool at runtime
- reload loggging conf on SIGHUP at runtime only if log config file has changed
- reload plugins (procpool) on SIGHUP at runtime only if main config file(s) has changed
- plugin Python3 fixes

Testing:
- unit/integration tests passed
- manual testing (Python 2/3), changing log-level/number or processes/pool at runtime