### PR TITLE
logQueue can be optional for MainController

### DIFF
--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -105,7 +105,19 @@ class MainController(object):
     appenders = []
     config = None
 
-    def __init__(self, config, logQueue, logProcessFacQueue=None):
+    def __init__(self, config, logQueue=None, logProcessFacQueue=None):
+        """
+        Main controller instance
+        Note: The logQueue and logProcessFacQueue keyword args are only needed in the fuglu main process when logging
+              to files. For default logging to the screen there is not logQueue needed.
+
+        Args:
+            config (configparser.RawConfigParser()): Config file parser (file already read)
+
+        Keyword Args:
+            logQueue (multiprocessing.queue or None): Queue where to put log messages (not directly used, only by loggers as defined in logtools.client_configurer)
+            logProcessFacQueue (multiprocessing.queue or None): Queue where to put new logging configurations (logtools.logConfig objects)
+        """
         self.requiredvars = {
             # main section
             'identifier': {

--- a/fuglu/tests/integration/endtoend_test.py
+++ b/fuglu/tests/integration/endtoend_test.py
@@ -40,7 +40,7 @@ class AllpluginTestCase(unittest.TestCase):
         config.set('main', 'disablebounces', '1')
         guess_clamav_socket(config)
 
-        self.mc = MainController(config,None)
+        self.mc = MainController(config)
         self.tempfiles = []
 
     def tearDown(self):
@@ -94,7 +94,7 @@ class EndtoEndTestTestCase(unittest.TestCase):
             'main', 'controlport', str(EndtoEndTestTestCase.FUGLUCONTROL_PORT))
         guess_clamav_socket(self.config)
         # init core
-        self.mc = MainController(self.config,None)
+        self.mc = MainController(self.config)
 
         # start listening smtp dummy server to get fuglus answer
         self.smtp = DummySMTPServer(
@@ -180,7 +180,7 @@ class DKIMTestCase(unittest.TestCase):
         guess_clamav_socket(self.config)
 
         # init core
-        self.mc = MainController(self.config, None)
+        self.mc = MainController(self.config)
 
         # start listening smtp dummy server to get fuglus answer
         self.smtp = DummySMTPServer(self.config, self.config.getint(
@@ -257,7 +257,7 @@ class SMIMETestCase(unittest.TestCase):
         guess_clamav_socket(self.config)
 
         # init core
-        self.mc = MainController(self.config,None)
+        self.mc = MainController(self.config)
 
         # start listening smtp dummy server to get fuglus answer
         self.smtp = DummySMTPServer(


### PR DESCRIPTION
logQueue can be optional for MainController since only needed when run 'fuglu' with file logging, not for any other tool which logs to screen