### PR TITLE
Shutdown pools

### DIFF
--- a/fuglu/doc/CHANGELOG
+++ b/fuglu/doc/CHANGELOG
@@ -5,6 +5,7 @@
 
 Developers:
  * extended signature of scan_stream function in AV plugins / new subclass shared.AVScannerPlugin
+ * Fix for CentOS-6 system script to correctly stop all processes
 
 
 -- Fuglu 0.8.0, 2018-04-23

--- a/fuglu/scripts/startscripts/centos_rhel/6/fuglu
+++ b/fuglu/scripts/startscripts/centos_rhel/6/fuglu
@@ -5,7 +5,11 @@
 # chkconfig: 2345 65 38
 # description: Mail Content Scanner Interface
 # processname: fuglu
+# pidfile: /var/run/fuglud.pid
+#
+# the old pid file written by fuglu
 # pidfile: /var/run/fuglu.pid
+# is not in use anymore for CentOS-6
 
 # Source function library.
 . /etc/rc.d/init.d/functions
@@ -17,7 +21,7 @@
 case "$1" in
   start)
         echo -n "Starting FuGlu Mail Content Scanner: "
-        daemon /usr/bin/fuglu
+        daemon /usr/bin/fuglu --pidfile=/var/run/fuglud.pid
         RETVAL=$?
         echo
         ;;

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -687,7 +687,7 @@ class MainController(object):
                     self.logger.info('Threadpool config changed, initialising new threadpool')
                     currentthreadpool = self.threadpool
                     self.threadpool = self._start_threadpool()
-                    currentthreadpool.stayalive = False
+                    currentthreadpool.shutdown()
                 else:
                     self.logger.info('Keep existing threadpool')
             else:
@@ -716,7 +716,7 @@ class MainController(object):
             # stop existing threadpool
             if self.threadpool is not None:
                 self.logger.info('Delete old threadpool')
-                self.threadpool.stayalive = False
+                self.threadpool.shutdown()
                 self.threadpool = None
         else:
             self.logger.error('backend not detected -> ignoring input!')
@@ -774,7 +774,7 @@ class MainController(object):
         # stop existing threadpool
         if self.threadpool is not None:
             self.logger.info('Delete threadpool')
-            self.threadpool.stayalive = False
+            self.threadpool.shutdown()
             self.threadpool = None
 
         self.stayalive = False

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -601,6 +601,7 @@ class MainController(object):
 
         self.logger.info('Startup complete')
         self._run_main_loop()
+        self.logger.info('Shutdown...')
         self.shutdown()
 
     def run_debugconsole(self):
@@ -765,10 +766,16 @@ class MainController(object):
         if self.controlserver is not None:
             self.controlserver.shutdown()
 
-        if self.threadpool:
+        # stop existing procpool
+        if self.procpool is not None:
+            self.logger.info('Delete procpool')
+            self.procpool.shutdown()
+            self.procpool = None
+        # stop existing threadpool
+        if self.threadpool is not None:
+            self.logger.info('Delete threadpool')
             self.threadpool.stayalive = False
-        if self.procpool:
-            self.procpool.stayalive = False
+            self.threadpool = None
 
         self.stayalive = False
         self.logger.info('Shutdown complete')

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -574,6 +574,11 @@ class MainController(object):
                     time.sleep(1)
                 except KeyboardInterrupt:
                     self.stayalive = False
+                except Exception as e:
+                    self.logger.error("Catched exception in main loop!")
+                    self.logger.exception(e)
+                    self.logger.error("Stopping!")
+                    self.stayalive = False
 
     def startup(self):
         self.load_extensions()

--- a/fuglu/src/fuglu/logtools.py
+++ b/fuglu/src/fuglu/logtools.py
@@ -179,6 +179,10 @@ def listener_process(configurer,queue):
     while True:
         try:
             record = queue.get()
+            if record is None:  # We send this as a sentinel to tell the listener to quit.
+                root.info("Listener process received poison pill")
+                break
+
             if logLogger:
                 logLogger.debug("Approx queue size: %u, received record to process -> %s"%(queue.qsize(),record))
 
@@ -187,8 +191,6 @@ def listener_process(configurer,queue):
                 if logLogger:
                     logLogger.error("QUEUE IS FULL!!!")
 
-            if record is None:  # We send this as a sentinel to tell the listener to quit.
-                break
             logger = logging.getLogger(record.name)
 
             # check if this record should be logged or not...

--- a/fuglu/src/fuglu/logtools.py
+++ b/fuglu/src/fuglu/logtools.py
@@ -35,9 +35,7 @@ def logFactoryProcess(listenerQueue,logQueue):
                                           process
 
     """
-    signal.signal(signal.SIGTERM, lambda signum, frame : None)
-    signal.signal(signal.SIGINT, lambda signum, frame : None)
-    signal.signal(signal.SIGHUP, lambda signum, frame : None)
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
 
     loggerProcess = None
     while True:
@@ -160,11 +158,7 @@ def listener_process(configurer,queue):
         queue (multiprocessing.Queue): The queue where log messages will be received and processed by this same process
     """
 
-    signal.signal(signal.SIGTERM, lambda signum, frame : None)
-    # SIGINT will be sent to the process if SIGTERM does not work,
-    # could also be set to None but might end up with processes not
-    # terminating properly
-    signal.signal(signal.SIGHUP, lambda signum, frame : None)
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
 
     configurer.configure()
     root = logging.getLogger()

--- a/fuglu/src/fuglu/procpool.py
+++ b/fuglu/src/fuglu/procpool.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 import multiprocessing
 import multiprocessing.queues
+import signal
 
 from fuglu.scansession import SessionHandler
 import fuglu.core
@@ -129,6 +130,13 @@ class MessageListener(threading.Thread):
 
 
 def fuglu_process_worker(queue, config, shared_state,child_to_server_messages, logQueue):
+
+    # the workers should not directly react on singals,
+    # singals will be handled by the controller and appropriate
+    # acctions will be passed to the workers using the queue
+    signal.signal(signal.SIGTERM, lambda signum, frame : None )
+    signal.signal(signal.SIGINT, lambda signum, frame : None )
+    signal.signal(signal.SIGHUP, lambda signum, frame : None)
 
     fuglu.logtools.client_configurer(logQueue)
     logging.basicConfig(level=logging.DEBUG)

--- a/fuglu/src/fuglu/procpool.py
+++ b/fuglu/src/fuglu/procpool.py
@@ -100,14 +100,13 @@ class ProcManager(object):
         # add another poison pill for the ProcManager itself removing tasks...
         self.tasks.put_nowait(None)
 
-        returnMessage = "Temporarily unavailable... Please try again"
+        returnMessage = "Temporarily unavailable... Please try again later."
         markDeferCounter = 0
         while True:
             task = self.tasks.get()
             if task is None: # poison pill
                 break
             markDeferCounter += 1
-            self.logger.debug("Remove message # %s from queue"%markDeferCounter)
             sock, handler_modulename, handler_classname = fuglu_process_unpack(task)
             handler_class = getattr(importlib.import_module(handler_modulename), handler_classname)
             handler_instance = handler_class(sock, self.config)
@@ -166,12 +165,7 @@ def fuglu_process_unpack(pickledTask):
 
 def fuglu_process_worker(queue, config, shared_state,child_to_server_messages, logQueue):
 
-    # the workers should not directly react on singals,
-    # singals will be handled by the controller and appropriate
-    # acctions will be passed to the workers using the queue
-    signal.signal(signal.SIGTERM, lambda signum, frame : None )
-    signal.signal(signal.SIGINT, lambda signum, frame : None )
-    signal.signal(signal.SIGHUP, lambda signum, frame : None)
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
 
     fuglu.logtools.client_configurer(logQueue)
     logging.basicConfig(level=logging.DEBUG)

--- a/fuglu/src/fuglu/threadpool.py
+++ b/fuglu/src/fuglu/threadpool.py
@@ -121,12 +121,7 @@ class ThreadPool(threading.Thread):
                 self.laststats = time.time()
 
             time.sleep(self.checkinterval)
-        for worker in self.workers:
-            worker.stayalive = False
-        for worker in self.workers:
-            worker.join(120)
 
-        del self.workers
         self.logger.info('Threadpool shut down')
 
     def _remove_worker(self, num=1):
@@ -145,6 +140,33 @@ class ThreadPool(threading.Thread):
             self.workers.append(worker)
             worker.start()
 
+    def shutdown(self):
+
+        # set stayalive to False, this will send
+        # poison pills to the workers
+        self.stayalive = False
+
+
+        # now remove elements from the queue
+        # first, put another poison pill for the Threadpool itself
+        self.tasks.put_nowait(None)
+        returnMessage = "Temporarily unavailable... Please try again later."
+        markDeferCounter = 0
+        while True:
+            # don't use the get_task from Threadpool since this will
+            # not give anything once stayalive is False
+            sesshandler = self.tasks.get(True)
+            if sesshandler == None:  # poison pill -> shut down
+                break
+            markDeferCounter += 1
+            sesshandler.protohandler.defer(returnMessage)
+
+        self.logger.info("Marked %s messages as '%s' to close queue" % (markDeferCounter,returnMessage))
+
+        # remove all the workers (joins them also)
+        for worker in self.workers:
+            worker.stayalive = False
+            worker.join(120) # wait 120 seconds max
 
 class Worker(threading.Thread):
 

--- a/fuglu/src/startscript/fuglu
+++ b/fuglu/src/startscript/fuglu
@@ -289,7 +289,6 @@ else:
 #--
 logProcessFactory = multiprocessing.Process(target=fuglu.logtools.logFactoryProcess,
                                      args=(logFactoryQueue,logQueue))
-#logProcessFactory.daemon = True
 logProcessFactory.start()
 
 # now create a log - listener process
@@ -335,8 +334,6 @@ if lint:
         print("(problems in the logging configuration could prevent the fuglu daemon from starting up)")
 
 else:
-    signal.signal(signal.SIGTERM, sigterm)
-    signal.signal(signal.SIGINT, sigterm)
     signal.signal(signal.SIGHUP, sighup)
     if console:
         controller.debugconsole = True
@@ -348,6 +345,7 @@ else:
 #---
 baselogger.info("Stop logging framework -> Goodbye")
 try:
+    baselogger.debug("Send Poison pill to logFactoryQueue")
     logFactoryQueue.put_nowait(None)
     logProcessFactory.join(120)
 except Exception as e:

--- a/fuglu/src/startscript/fuglu
+++ b/fuglu/src/startscript/fuglu
@@ -133,6 +133,19 @@ def reloadconfig():
         controller.reload()
 
 
+def sigterm(signum, frame):
+    """handle sigterm"""
+    logger = logging.getLogger('sigterm')
+    logger.debug("Process received SIGTERM (signal=%s)!"%signum)
+    if controller:
+        if controller.threadpool is None and controller.procpool is None:
+            return
+    else:
+        return
+
+    logger.info("Main Controller process received SIGTERM\nGoodbye!")
+    controller.stayalive = False
+
 def sighup(signum, frame):
     """handle sighup to reload config"""
     reloadconfig()
@@ -322,6 +335,8 @@ if lint:
         print("(problems in the logging configuration could prevent the fuglu daemon from starting up)")
 
 else:
+    signal.signal(signal.SIGTERM, sigterm)
+    signal.signal(signal.SIGINT, sigterm)
     signal.signal(signal.SIGHUP, sighup)
     if console:
         controller.debugconsole = True
@@ -331,6 +346,7 @@ else:
 #---
 # stop logger factory & process
 #---
+baselogger.info("Stop logging framework -> Goodbye")
 try:
     logFactoryQueue.put_nowait(None)
     logProcessFactory.join(120)

--- a/fuglu/src/startscript/fuglu
+++ b/fuglu/src/startscript/fuglu
@@ -133,19 +133,6 @@ def reloadconfig():
         controller.reload()
 
 
-def sigterm(signum, frame):
-    """handle sigterm"""
-    logger = logging.getLogger('sigterm')
-    logger.debug("Process received SIGTERM (signal=%s)!"%signum)
-    if controller:
-        if controller.threadpool is None and controller.procpool is None:
-            return
-    else:
-        return
-
-    logger.info("Main Controller process received SIGTERM\nGoodbye!")
-    controller.stayalive = False
-
 def sighup(signum, frame):
     """handle sighup to reload config"""
     reloadconfig()


### PR DESCRIPTION
Stopping fuglu daemon will immediately stop fuglu processes as it was already the case before this commits. Modifying backend will properly shutdown the pool and remove queue elements putting a temporarily unavailable as response.