### PR TITLE
Allow all ascii chars in sender/receiver local part of mail address

### DIFF
--- a/fuglu/conf/fuglu.conf.dist
+++ b/fuglu/conf/fuglu.conf.dist
@@ -92,6 +92,18 @@ logtemplate=Suspect ${id} from=${from_address} to=${to_address} size=${size} spa
 #Disable this if you consider the DNS lookup an unwanted information leak.
 versioncheck=1
 
+# Method to check mail address validity (Default/LazyLocalPart)
+address_compliance_checker = Default
+
+# Action to perform if address validity check fails (defer/reject/discard)
+address_compliance_fail_action = defer
+
+# Reply message if address validity check fails
+address_compliance_fail_message = invalid send or receive address
+
+# Remove temporary message file from disk for receive or address compliance errors
+remove_tmpfiles_on_error = True
+
 [PluginAlias]
 
 debug=fuglu.plugins.p_debug.MessageDebugger

--- a/fuglu/doc/CHANGELOG
+++ b/fuglu/doc/CHANGELOG
@@ -2,6 +2,8 @@
  * ClamAV plugin: Fix sending large files to ClamAV which caused timeouts
  * Attachment plugin: Improve file type detection of unnamed attachments
  * Spamassassin plugin: strip attachment function now generates proper mail format
+ * Configurable check for mail address validity, fail action and message
+ * Configuration option to remove (default) or keep temporary message files on internal errors (receive,address,unknown)
 
 Developers:
  * extended signature of scan_stream function in AV plugins / new subclass shared.AVScannerPlugin

--- a/fuglu/src/fuglu/MailAddrLegitimateChecker.py
+++ b/fuglu/src/fuglu/MailAddrLegitimateChecker.py
@@ -1,0 +1,30 @@
+import re
+
+class MailAddrLegCheckerInterface(object):
+    def __init__(self):
+        pass
+    def __call__(self,mailAddress):
+        raise NotImplemented
+
+class Default(MailAddrLegCheckerInterface):
+    """
+    Default implementation (and backward compatible) which does not allow more than one '@'
+    """
+    def __init__(self):
+        super(Default, self).__init__()
+    def __call__(self,mailAddress):
+        leg =  mailAddress !='' and  (   re.match(r"[^@]+@[^@]+$", mailAddress))
+        return leg
+
+class LazyQuotedLocalPart(MailAddrLegCheckerInterface):
+    """
+    Allows '@' in local part if quoted
+    """
+    def __init__(self):
+        super(LazyQuotedLocalPart, self).__init__()
+    def __call__(self,mailAddress):
+        leg =  mailAddress !='' and  (   re.match(r"[^@]+@[^@]+$", mailAddress)
+                                      or re.match(r"^\"[\x00-\x7f]+\"@[^@]+$", mailAddress)
+                                      or re.match(r"^\'[\x00-\x7f]+\'@[^@]+$", mailAddress) )
+        return leg
+

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -270,6 +270,17 @@ class MainController(object):
                 'default': '1',
             },
 
+            'address_compliance_checker': {
+                'section': 'main',
+                'description': "Class implementing MailAddrLegCheckerInterface to perform a quick internal check to determine if mail addres is legitimate",
+                'default': "Default",
+            },
+            'address_compliance_fail_action': {
+                'section': 'main',
+                'description': "Action to perform if address compliance check fails (\"defer\",\"reject\",\"drop\")",
+                'default': "defer",
+            },
+
             # performance section
             'minthreads': {
                 'default': "2",

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -272,13 +272,23 @@ class MainController(object):
 
             'address_compliance_checker': {
                 'section': 'main',
-                'description': "Class implementing MailAddrLegCheckerInterface to perform a quick internal check to determine if mail addres is legitimate",
+                'description': "Method to check mail address validity (\"Default\",\"LazyLocalPart\")",
                 'default': "Default",
             },
             'address_compliance_fail_action': {
                 'section': 'main',
-                'description': "Action to perform if address compliance check fails (\"defer\",\"reject\",\"drop\")",
+                'description': "Action to perform if address validity check fails (\"defer\",\"reject\",\"discard\")",
                 'default': "defer",
+            },
+            'address_compliance_fail_message': {
+                'section': 'main',
+                'description': "Reply message if address validity check fails",
+                'default': "invalid send or receive address",
+            },
+            'remove_tmpfiles_on_error': {
+                'section': 'main',
+                'description': "Remove temporary message file from disk for receive or address compliance errors",
+                'default': True,
             },
 
             # performance section

--- a/fuglu/src/fuglu/protocolbase.py
+++ b/fuglu/src/fuglu/protocolbase.py
@@ -20,6 +20,7 @@ import threading
 from fuglu.scansession import SessionHandler
 import traceback
 from multiprocessing.reduction import ForkingPickler
+import os
 try:
     from StringIO import StringIO
 except ImportError:
@@ -35,6 +36,23 @@ class ProtocolHandler(object):
         self.socket = socket
         self.config = config
         self.logger = logging.getLogger('fuglu.%s' % self.__class__.__name__)
+        self.sess = None
+
+    def remove_tmpfile(self):
+        tmpfile = self.get_tmpfile()
+        if tmpfile is not None:
+            try:
+                os.remove(tmpfile)
+            except OSError:
+                pass
+
+    def get_tmpfile(self):
+        if self.sess is not None:
+            try:
+                tmpfilename = self.sess.tempfilename
+            except AttributeError:
+                tmpfilename = None
+        return tmpfilename
 
     def get_suspect(self):
         return None

--- a/fuglu/src/fuglu/scansession.py
+++ b/fuglu/src/fuglu/scansession.py
@@ -55,24 +55,25 @@ class SessionHandler(object):
         # setup compliance checker if not already set up
         #--
         #
-        # Mail Address compliance check is global
-        if Suspect.addrIsLegitimate is None:
-            addComCheck = self.config.get('main','address_compliance_checker')
-            if addComCheck == "Default":
-                Suspect.addrIsLegitimate = Default()
-            elif addComCheck == "LazyQuotedLocalPart":
-                Suspect.addrIsLegitimate = LazyQuotedLocalPart()
-            else:
-                self.logger.error('Address Compliance Checker not recognized -> use Default')
-                Suspect.addrIsLegitimate = Default()
+        # Mail Address compliance check is global, make sure it is updated when config is changed
+        addComCheck = self.config.get('main','address_compliance_checker')
+        if addComCheck == "Default" and not isinstance(Suspect.addrIsLegitimate,Default):
+            Suspect.addrIsLegitimate = Default()
+        elif addComCheck == "LazyQuotedLocalPart" and not isinstance(Suspect.addrIsLegitimate,LazyQuotedLocalPart):
+            Suspect.addrIsLegitimate = LazyQuotedLocalPart()
+        else:
+            self.logger.error('Address Compliance Checker not recognized -> use Default')
+            Suspect.addrIsLegitimate = Default()
 
         prependheader = self.config.get('main', 'prependaddedheaders')
         try:
+            suspect = None
             self.set_workerstate('receiving message')
             suspect = self.protohandler.get_suspect()
             if suspect is None:
                 self.logger.error('No Suspect retrieved, ending session')
                 return
+
             self.stats.increase_counter_values(StatDelta(in_=1))
 
             if len(suspect.recipients) != 1:
@@ -171,6 +172,7 @@ class SessionHandler(object):
             try:
                 os.remove(suspect.tempfile)
                 self.logger.debug('Removed tempfile %s' % suspect.tempfile)
+                suspect.tempfile = None
             except OSError:
                 self.logger.warning('Could not remove tempfile %s' % suspect.tempfile)
         except KeyboardInterrupt:
@@ -178,20 +180,73 @@ class SessionHandler(object):
         except ValueError:
             # Error in envelope send/receive address
             address_compliance_fail_action = self.config.get('main','address_compliance_fail_action').lower()
-            message = "invalid send or receive address"
-            if address_compliance_fail_action == "defer":
+
+            message = self.config.get('main','address_compliance_fail_message')
+
+            if address_compliance_fail_action   == "defer":
                 self._defer(message)
             elif address_compliance_fail_action == "reject":
-                self.protohandler.reject(message)
+                self._reject(message)
+            elif address_compliance_fail_action == "discard":
+                self._discard(message)
             else:
                 self._defer(message)
+
         except Exception as e:
             exc = traceback.format_exc()
             self.logger.error('Exception %s: %s' % (e, exc))
             self._defer()
 
+        finally:
+            # finally is also executed if there's a return statement somewhere in try-except
+
+            if suspect is None:
+                # if there was an error creating the suspect, check if the filename can be
+                # extracted from the protohandler
+                tmpfilename = self.protohandler.get_tmpfile()
+                if tmpfilename is None:
+                    tmpfilename = ""
+                if self.config.getboolean('main', 'remove_tmpfiles_on_error'):
+                    self.logger.debug('Remove tmpfile: %s for failed message' % tmpfilename)
+                    self.protohandler.remove_tmpfile()
+                else:
+                    self.logger.warning('Keep tmpfile: %s for failed message' % tmpfilename)
+
+            elif suspect.tempfile is not None:
+                # suspect was created but not stopped cleanly
+                if self.config.getboolean('main', 'remove_tmpfiles_on_error'):
+                    try:
+                        os.remove(suspect.tempfile)
+                        self.logger.debug('Removed tempfile %s' % suspect.tempfile)
+                    except OSError:
+                        self.logger.warning('Could not remove tempfile %s' % suspect.tempfile)
+                else:
+                    self.logger.warning('Keep tempfile %s for failed message' % suspect.tempfile)
+
         self.logger.debug('Session finished')
 
+
+    def _discard(self, message=None):
+        if message is None:
+            message="internal problem - discard"
+
+        # try to end the session gracefully, but this might cause the same exception again,
+        # in case of a broken pipe for example
+        try:
+            self.protohandler.discard(message)
+        except Exception:
+            pass
+
+    def _reject(self, message=None):
+        if message is None:
+            message="internal problem - reject"
+
+        # try to end the session gracefully, but this might cause the same exception again,
+        # in case of a broken pipe for example
+        try:
+            self.protohandler.reject(message)
+        except Exception:
+            pass
 
     def _defer(self, message=None):
         if message is None:

--- a/fuglu/src/fuglu/shared.py
+++ b/fuglu/src/fuglu/shared.py
@@ -205,7 +205,9 @@ class Suspect(object):
         for rec in self.recipients:
             if rec is None:
                 raise ValueError("Recipient address can not be None")
-            if not re.match(r"[\x00-\x7f]+@[^@]+$", rec):
+            if not (re.match(r"[^@]+@[^@]+$", rec)
+                    or re.match(r"^\"[\x00-\x7f]+\"@[^@]+$", rec)
+                    or re.match(r"^\'[\x00-\x7f]+\'@[^@]+$", rec) ):
                 raise ValueError("Invalid recipient address: %s"%rec)
 
 
@@ -219,7 +221,9 @@ class Suspect(object):
         if self.from_address is None:
             self.from_address = ''
 
-        if self.from_address!='' and  not re.match(r"[\x00-\x7f]+@[^@]+$", self.from_address):
+        if self.from_address!='' and  not (re.match(r"[^@]+@[^@]+$", self.from_address)
+                                           or re.match(r"^\"[\x00-\x7f]+\"@[^@]+$", self.from_address)
+                                           or re.match(r"^\'[\x00-\x7f]+\'@[^@]+$", self.from_address) ):
             raise ValueError("invalid sender address: %s"%self.from_address)
 
         self.clientinfo = None

--- a/fuglu/src/fuglu/shared.py
+++ b/fuglu/src/fuglu/shared.py
@@ -22,6 +22,7 @@ import time
 import socket
 import uuid
 import threading
+import fuglu.MailAddrLegitimateChecker
 from fuglu.localStringEncoding import force_uString, force_bString
 try:
     from html.parser import HTMLParser
@@ -171,6 +172,7 @@ class Suspect(object):
     The suspect represents the message to be scanned. Each scannerplugin will be presented
     with a suspect and may modify the tags or even the message content itself.
     """
+    addrIsLegitimate = None
 
     def __init__(self, from_address, recipients, tempfile):
         self.source = None
@@ -201,13 +203,15 @@ class Suspect(object):
         else:
             self.recipients = [recipients, ]
 
+        # setup checker for email validation if not already set
+        if Suspect.addrIsLegitimate is None:
+            Suspect.addrIsLegitimate = fuglu.MailAddrLegitimateChecker.Default()
+
         # basic email validitiy check - nothing more than necessary for our internal assumptions
         for rec in self.recipients:
             if rec is None:
                 raise ValueError("Recipient address can not be None")
-            if not (re.match(r"[^@]+@[^@]+$", rec)
-                    or re.match(r"^\"[\x00-\x7f]+\"@[^@]+$", rec)
-                    or re.match(r"^\'[\x00-\x7f]+\'@[^@]+$", rec) ):
+            if not Suspect.addrIsLegitimate(rec):
                 raise ValueError("Invalid recipient address: %s"%rec)
 
 
@@ -221,9 +225,7 @@ class Suspect(object):
         if self.from_address is None:
             self.from_address = ''
 
-        if self.from_address!='' and  not (re.match(r"[^@]+@[^@]+$", self.from_address)
-                                           or re.match(r"^\"[\x00-\x7f]+\"@[^@]+$", self.from_address)
-                                           or re.match(r"^\'[\x00-\x7f]+\'@[^@]+$", self.from_address) ):
+        if self.from_address != '' and not Suspect.addrIsLegitimate(self.from_address):
             raise ValueError("invalid sender address: %s"%self.from_address)
 
         self.clientinfo = None

--- a/fuglu/src/fuglu/shared.py
+++ b/fuglu/src/fuglu/shared.py
@@ -205,7 +205,7 @@ class Suspect(object):
         for rec in self.recipients:
             if rec is None:
                 raise ValueError("Recipient address can not be None")
-            if not re.match(r"[^@]+@[^@]+$", rec):
+            if not re.match(r"[\x00-\x7f]+@[^@]+$", rec):
                 raise ValueError("Invalid recipient address: %s"%rec)
 
 
@@ -219,7 +219,7 @@ class Suspect(object):
         if self.from_address is None:
             self.from_address = ''
 
-        if self.from_address!='' and  not re.match(r"[^@]+@[^@]+$", self.from_address):
+        if self.from_address!='' and  not re.match(r"[\x00-\x7f]+@[^@]+$", self.from_address):
             raise ValueError("invalid sender address: %s"%self.from_address)
 
         self.clientinfo = None

--- a/fuglu/tests/unit/shared_test.py
+++ b/fuglu/tests/unit/shared_test.py
@@ -2,6 +2,7 @@ from unittestsetup import TESTDATADIR
 import unittest
 import string
 from fuglu.shared import Suspect, SuspectFilter, string_to_actioncode, actioncode_to_string, apply_template, REJECT, FileList
+from fuglu.MailAddrLegitimateChecker import Default, LazyQuotedLocalPart
 import os
 
 try:
@@ -75,6 +76,10 @@ class SuspectTestCase(unittest.TestCase):
 
     def test_special_local_part(self):
         """Make sure Sender/Receiver with quoted local part are received correctly and can contain '@'"""
+        Suspect.addrIsLegitimate = Default()
+        self.assertRaises(ValueError, Suspect, "sender@example.net", "recipient@example.com@example.org", '/dev/null')
+
+        Suspect.addrIsLegitimate = LazyQuotedLocalPart()
         s = Suspect('"bob@remotehost"@localhost', "'root@localhost'@remotehost", '/dev/null')
         self.assertEqual('"bob@remotehost"@localhost', s.from_address)
         self.assertEqual('"bob@remotehost"', s.from_localpart)

--- a/fuglu/tests/unit/shared_test.py
+++ b/fuglu/tests/unit/shared_test.py
@@ -73,6 +73,16 @@ class SuspectTestCase(unittest.TestCase):
         self.assertRaises(ValueError, Suspect, "sender", "recipient@example.com", '/dev/null')
         self.assertRaises(ValueError, Suspect, "sender@example.net", "recipient@example.com@example.org", '/dev/null')
 
+    def test_special_local_part(self):
+        """Make sure Sender/Receiver with quoted local part are received correctly and can contain '@'"""
+        s = Suspect('"bob@remotehost"@localhost', "'root@localhost'@remotehost", '/dev/null')
+        self.assertEqual('"bob@remotehost"@localhost', s.from_address)
+        self.assertEqual('"bob@remotehost"', s.from_localpart)
+        self.assertEqual("localhost", s.from_domain)
+
+        self.assertEqual("'root@localhost'@remotehost", s.to_address)
+        self.assertEqual("'root@localhost'", s.to_localpart)
+        self.assertEqual("remotehost", s.to_domain)
 
 class SuspectFilterTestCase(unittest.TestCase):
 


### PR DESCRIPTION
- before only one '@' was allowed in whole mail address
- but "a@b"@c is legitimate (local part has to be in quotes)
- we don't check for "" around the local part if finding special chars since we assume these invalid addresses would be dectected before fuglu