### PR TITLE
fix missing STATUS in dnsquery.py

### DIFF
--- a/fuglu/src/fuglu/extensions/dnsquery.py
+++ b/fuglu/src/fuglu/extensions/dnsquery.py
@@ -15,10 +15,12 @@
 #
 #
 #
+STATUS = "not loaded"
 
 try:
     from dns import resolver
     HAVE_DNSPYTHON=True
+    STATUS = "available"
 except ImportError:
     resolver = None
     HAVE_DNSPYTHON=False
@@ -29,8 +31,10 @@ if not HAVE_DNSPYTHON:
         import DNS
         HAVE_PYDNS=True
         DNS.DiscoverNameServers()
+        STATUS = "available"
     except ImportError:
         DNS = None
+        STATUS = "DNS not installed"
 
 ENABLED = DNSQUERY_EXTENSION_ENABLED = HAVE_DNSPYTHON or HAVE_PYDNS
 
@@ -56,13 +60,13 @@ def lookup(hostname, qtype=QTYPE_A):
             for rec in arequest:
                 arecs.append(rec.to_text())
             return arecs
-        
+
         elif HAVE_PYDNS:
             return DNS.dnslookup(hostname, qtype)
-    
+
     except Exception:
         return None
-    
+
     return None
 
 
@@ -76,20 +80,20 @@ def mxlookup(domain):
                 mxrecs.append(rec.to_text())
             mxrecs.sort()  # automatically sorts by priority
             return [x.split(None, 1)[-1] for x in mxrecs]
-        
+
         elif HAVE_PYDNS:
             mxrecs = []
             mxrequest = DNS.mxlookup(domain)
             for dataset in mxrequest:
                 if type(dataset) == tuple:
                     mxrecs.append(dataset)
-            
+
             mxrecs.sort()  # automatically sorts by priority
             return [x[1] for x in mxrecs]
-    
+
     except Exception:
         return None
-    
+
     return None
 
 
@@ -99,5 +103,3 @@ def revlookup(ip):
     a.reverse()
     revip = '.'.join(a)+'.in-addr.arpa'
     return lookup(revip, qtype=QTYPE_PTR)
-
-


### PR DESCRIPTION
In new fuglu version dnsquery is loaded as an extension. But when we launch fuglu --lint, there is an error due to STATUS attr missing. I fixed this in dnsquery.py.

