### PR TITLE
speedup Suspect.get_decoded_textparts using content charset

### DIFF
--- a/fuglu/src/fuglu/shared.py
+++ b/fuglu/src/fuglu/shared.py
@@ -1073,7 +1073,10 @@ class SuspectFilter(object):
 
             # payload can be None even if it was returned from part.get_payload()
             if payload is not None:
-                textparts.append(force_uString(payload))
+                # Try to decode using the given char set
+                charset = part.get_content_charset("utf-8")
+                payload = force_uString(payload,encodingGuess=charset)
+                textparts.append(payload)
         return textparts
 
     def get_field(self, suspect, headername):

--- a/fuglu/src/fuglu/stringencode.py
+++ b/fuglu/src/fuglu/stringencode.py
@@ -35,7 +35,8 @@ def try_decoding(b_inputstring,encodingGuess="utf-8"):
 
     Args:
         b_inputstring (str/bytes): input byte string
-        encodingGuess (str): guess for encoding used
+    Keyword Args:
+        encodingGuess (str): guess for encoding used, default assume unicode
 
     Returns:
         unicode string
@@ -70,11 +71,13 @@ def try_decoding(b_inputstring,encodingGuess="utf-8"):
     return u_outputstring
 
 
-def force_uString(inputstring):
+def force_uString(inputstring,encodingGuess="utf-8"):
     """Try to enforce a unicode string
     
     Args:
         inputstring (str, unicode, list): input string or list of strings to be checked
+    Keyword Args:
+        encodingGuess (str): guess for encoding used, default assume unicode
 
     Returns: unicode string (or list with unicode strings)
 
@@ -90,7 +93,7 @@ def force_uString(inputstring):
         if isinstance(inputstring,str):
             return inputstring
         else:
-            return try_decoding(inputstring)
+            return try_decoding(inputstring,encodingGuess)
     else:
         # Python 2.x
         # the basic "str" type is bytes, unicode
@@ -98,7 +101,7 @@ def force_uString(inputstring):
         if isinstance(inputstring,unicode):
             return inputstring
         else:
-            return try_decoding(inputstring)
+            return try_decoding(inputstring,encodingGuess)
 
 
 def force_bString(inputstring,encoding="utf-8",checkEncoding=False):

--- a/fuglu/src/fuglu/stringencode.py
+++ b/fuglu/src/fuglu/stringencode.py
@@ -48,8 +48,8 @@ def try_decoding(b_inputstring,encodingGuess="utf-8"):
     logger = logging.getLogger("fuglu.encoding.try_decoding")
     try:
         u_outputstring = b_inputstring.decode(encodingGuess,"strict")
-    except UnicodeDecodeError:
-        logger.warning("found non %s encoding, try to detect encoding" % encodingGuess)
+    except (UnicodeDecodeError, LookupError):
+        logger.warning("found non %s encoding or encoding not found, try to detect encoding" % encodingGuess)
         if chardetAvailable:
             encoding = chardet.detect(b_inputstring)['encoding']
             logger.warning("encoding estimated as %s" % encoding)


### PR DESCRIPTION
get_decoded_textparts has to do proper decoding of the message parts to
work with python 3 properly. Until now unicode was used as a guess for decoding
the payload. If this fails, chardet is used to find the correct  encoding. 
However, chardet will use significant resources to detect the character set. This commit
is using the charset as defined in the mail for the encoding which avoid the use of chardet
if correctly defined in the mail.