### PR TITLE
fix log message for misleading string decode error

### DIFF
--- a/fuglu/src/fuglu/stringencode.py
+++ b/fuglu/src/fuglu/stringencode.py
@@ -50,6 +50,10 @@ def try_encoding(u_inputstring,encoding="utf-8"):
 def try_decoding(b_inputstring,encodingGuess="utf-8"):
     """ Try to decode an encoded string
 
+    This will raise exceptions if object can not be decoded. The calling
+    routine has to handle the exception. For example, "force_uString" has
+    to handle exceptions for sending non-encoded strings.
+
     Args:
         b_inputstring (str/bytes): input byte string
     Keyword Args:
@@ -77,10 +81,6 @@ def try_decoding(b_inputstring,encodingGuess="utf-8"):
         else:
             logger.warning("module chardet not available -> skip autodetect")
             raise UnicodeDecodeError
-    except Exception as e:
-        logger.error("decoding failed!")
-        logger.exception(e)
-        raise e
 
     return u_outputstring
 
@@ -117,7 +117,7 @@ def force_uString(inputstring,encodingGuess="utf-8"):
                 return inputstring
             else:
                 return try_decoding(inputstring,encodingGuess)
-    except AttributeError:
+    except (AttributeError,TypeError):
         # Input might not be bytes but a number which is then
         # expected to be converted to unicode
         try:

--- a/fuglu/tests/unit/stringencode_test.py
+++ b/fuglu/tests/unit/stringencode_test.py
@@ -59,3 +59,6 @@ class ConversionTest(unittest.TestCase):
 
         self.assertEqual(ustringtype,type(force_uString(WithUnicode())),"Class has __unicode__ and __str__ (Py2: __unicode__ / Py3: __str__")
         self.assertEqual(ustringtype,type(force_uString(WithStr())),"Class has __str__ (Py2/3: __str__")
+
+        for item in force_uString([int(1), "bla", 1.3e-2]):
+            self.assertEqual(ustringtype,type(item),"After conversion, type has to be unicode")


### PR DESCRIPTION
no problem in `string_decode`
`force_uString` uses Exceptions in string_decode to detect
non-encoded-string inputs like integers and converts them directly to unicode string.
Therefore, `string_decode` should not write to the log-file and just raise an Exception on error