### PR TITLE
allow binding incoming ports to different addresses

### DIFF
--- a/fuglu/doc/CHANGELOG
+++ b/fuglu/doc/CHANGELOG
@@ -8,6 +8,7 @@
  * Configuration option to remove (default) or keep temporary message files on internal errors (receive,address,unknown)
  * new input "att_mgr_cachesize" to define attachment manager cache size
  * new input "archiveextractlevel" in FiletypePlugin to define attachment archive extract level
+ * allow binding incoming ports to different addresses
 
 Developers:
  * extended signature of scan_stream function in AV plugins / new subclass shared.AVScannerPlugin


### PR DESCRIPTION
Allow binding connectors to different addresses (for example external/local) defining
an address between the protocol and the port, separated by ":"

fuglu:conf
```conf
bindaddress=xxx.xxx.xxx.xxx
incomingport=10888,netcat:10889,milter:127.0.0.1:10028
```